### PR TITLE
Not all non-"running" statuses indicate complete

### DIFF
--- a/src/jobs/workflow-collector.yml
+++ b/src/jobs/workflow-collector.yml
@@ -107,9 +107,9 @@ steps:
               # echo $JOB_DATA_RAW > /tmp/sumologic-logs/job-collector.json
               # curl -s -X POST -T /tmp/sumologic-logs/job-collector.json $<< parameters.job-collector >>
               ###
-              if [ "$JOB_STATUS" != '"running"' ];
+              if [ "$JOB_STATUS" == '"success"' ] || [ "$JOB_STATUS" == '"failed"' ];
               then
-                echo "Job $CIRCLE_JOB $JOB_NUMBER is complete - $JOB_STATUS"
+                echo "Job $JOB_NAME $JOB_NUMBER is complete - $JOB_STATUS"
               else
                 # If it is still running, then mark WF_FINISHED as false.
                 WF_FINISHED=false


### PR DESCRIPTION
there is also blocked and queued.

### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Fixing
```
parse error: Invalid numeric literal at line 1, column 10
Exited with code 4
```
bug.  It is getting passed the completion check when job_number is still null because the completion check is faulty.  It assumes any non-running status indicates the job is done.

### Description

Moved from a "status != 'running'" to a whitelist "status in ['success', 'failed']".

Should I include "cancelled" in there?
