### PR TITLE
Update CircleCI path from /jobs to /job to match recent change

### DIFF
--- a/src/jobs/workflow-collector.yml
+++ b/src/jobs/workflow-collector.yml
@@ -22,7 +22,7 @@ steps:
         ###############
         # Begin Collecting
         ###############
-        DATA_URL="https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID/jobs?circle-token=$<< parameters.circle-token >>"
+        DATA_URL="https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID/job?circle-token=$<< parameters.circle-token >>"
         WF_DATA=$(curl -s "$DATA_URL" | jq '.items')
         WF_LENGTH=$(echo "$WF_DATA" | jq length)
         # GET URL PATH DATA


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues
This change updates the CircleCI API endpoint from `/workflow/:workflow-id/jobs` to `workflow/:workflow-id/job` to match the [change on November 18th](https://github.com/CircleCI-Public/api-preview-docs/blob/master/docs/breaking.md#nov-11-2019). Without this change, the workflow collector job will fail immediately.
<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
