### PR TITLE
exit early with descriptive message when no workflow is found

### DIFF
--- a/src/jobs/workflow-collector.yml
+++ b/src/jobs/workflow-collector.yml
@@ -23,8 +23,17 @@ steps:
         # Begin Collecting
         ###############
         DATA_URL="https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID/job?circle-token=$<< parameters.circle-token >>"
-        WF_DATA=$(curl -s "$DATA_URL" | jq '.items')
-        WF_LENGTH=$(echo "$WF_DATA" | jq length)
+        WF_DATA=$(curl -s "$DATA_URL")
+        WF_MESSAGE=$(echo "$WF_DATA" | jq '.message')
+        # Exit if no Workflow.
+        if [ "$WF_MESSAGE" = "\"Workflow not found\"" ];
+        then
+          echo "No Workflow was found."
+          echo "Your circle-token parameter may be wrong or you do not have access to this Workflow."
+          exit 1
+        fi
+        WF_ITEMS=$(echo "$WF_DATA" | jq '.items')
+        WF_LENGTH=$(echo "$WF_ITEMS" | jq length)
         # GET URL PATH DATA
         VCS_SHORT=$(echo $CIRCLE_BUILD_URL | cut -d"/" -f4)
         case $VCS_SHORT in


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

I was using an old circleci token and the existing error output was not as helpful as it could be.

### Description

Check for a top level `message` key in the response and if it contains "Workflow not found" exit early giving a descriptive reason why.
