### PR TITLE
Add support for 'on_hold' job status

### DIFF
--- a/src/jobs/workflow-collector.yml
+++ b/src/jobs/workflow-collector.yml
@@ -119,9 +119,9 @@ steps:
               if [ "$JOB_STATUS" == '"success"' ] || [ "$JOB_STATUS" == '"failed"' ];
               then
                 echo "Job $JOB_NAME $JOB_NUMBER is complete - $JOB_STATUS"
-              elif [ "$JOB_STATUS" == '"on_hold"' ];
+              elif [ "$JOB_STATUS" == '"on_hold"' ] || [ "$JOB_STATUS" == '"blocked"' ];
               then
-                # The condition to not block metrics sending when workflow use manually approved steps.
+                # The condition to not block metrics sending when workflow use manually approved steps or is blocked.
                 echo "Job $JOB_NAME $JOB_NUMBER need manual approval - $JOB_STATUS - skipping"
               else
                 # If it is still running, then mark WF_FINISHED as false.

--- a/src/jobs/workflow-collector.yml
+++ b/src/jobs/workflow-collector.yml
@@ -119,6 +119,9 @@ steps:
               if [ "$JOB_STATUS" == '"success"' ] || [ "$JOB_STATUS" == '"failed"' ];
               then
                 echo "Job $JOB_NAME $JOB_NUMBER is complete - $JOB_STATUS"
+              elif [ "$JOB_STATUS" == '"on_hold"' ];
+              then
+                echo "Job $JOB_NAME $JOB_NUMBER need manual approval - $JOB_STATUS - skipping"
               else
                 # If it is still running, then mark WF_FINISHED as false.
                 WF_FINISHED=false

--- a/src/jobs/workflow-collector.yml
+++ b/src/jobs/workflow-collector.yml
@@ -121,6 +121,7 @@ steps:
                 echo "Job $JOB_NAME $JOB_NUMBER is complete - $JOB_STATUS"
               elif [ "$JOB_STATUS" == '"on_hold"' ];
               then
+                # The condition to not block metrics sending when workflow use manually approved steps.
                 echo "Job $JOB_NAME $JOB_NUMBER need manual approval - $JOB_STATUS - skipping"
               else
                 # If it is still running, then mark WF_FINISHED as false.


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [n/a] Examples have been added for any significant new features
- [n/a] README has been updated, if necessary

### Motivation, issues

The workflow can use the 'Manual approval' feature which returns 'status: "on_hold"', currently the Orb is not supporting it and causes infinite loop (screenshot below).
<img width="215" alt="Zrzut ekranu 2020-01-30 o 20 57 47" src="https://user-images.githubusercontent.com/6168442/73513796-eccfe800-43a3-11ea-9dea-c2bc0c704714.png">

Related also to issue: https://github.com/CircleCI-Public/sumologic-orb/issues/17

### Description

Added 'if' statement in the status checking
