### PR TITLE
No fail if sumologic collector is only job

### DIFF
--- a/src/jobs/workflow-collector.yml
+++ b/src/jobs/workflow-collector.yml
@@ -49,14 +49,13 @@ steps:
         esac
         # Assume the WF is currently running
         WF_FINISHED=false
-        echo "Jobs in Workflow: $WF_LENGTH"
-        echo
+        echo -e "Jobs in Workflow: $WF_LENGTH \n"
         # Exit if no other jobs in the Workflow.
         if [ "$WF_LENGTH" -lt 2 ];
         then
           echo "Only a single job has been found in the workflow, indicating this reporter is the only job in the pipeline."
           echo "Please add other jobs to the Workflow you wish to collect data on to send to Sumologic"
-          exit 1
+          exit 0
         fi
         #####################
         ## START MAIN LOOP ##


### PR DESCRIPTION
### Checklist

- [n/a] All new jobs, commands, executors, parameters have descriptions
- [n/a] Examples have been added for any significant new features
- [n/a] README has been updated, if necessary

### Motivation, issues
Some advanced workflows use filtering in the run, so there is a case that the whole workflow run is only a Sumologic collector and it returns an error and long stack trace. 
More convenient is to finish successfully with brief information.

### Description

changed `exit 1` to `0`
