### PR TITLE
[semver:minor] Add support for custom data.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@ https://circleci.com/orbs/registry/orb/circleci/sumologic
 Easily capture analytics from your CircleCI jobs in your Sumologic dashboard!
 
 ## workflow-collector
-Add this job to your workflow with no require statements. This job will run in parallel with the rest of your workflow for monitoring and will exit when all other jobs have completed.
+Add this job to your workflow with no require statements. This job will run in parallel with the rest of your workflow for monitoring and will exit when all other jobs have completed. Custom data can be supplied via the custom-data parameter in the form of valid JSON. Keys and values can be supplied literally or as environment variables, though supplying values as additional, nested JSON is not supported. Passing the custom-data parameter as a folded-style (>) block scalar is recommended (see examples).
 

--- a/src/examples/workflow_collector.yml
+++ b/src/examples/workflow_collector.yml
@@ -23,7 +23,7 @@ usage:
   workflows:
     build-test-and-deploy:
       jobs:
-        - sumologic/workflow-collector
+        - sumologic/workflow-collector:
             custom-data: >
               {"foo": "bar", "$SOME_KEY_VAR": "$SOME_VALUE_VAR"}
         - build

--- a/src/examples/workflow_collector.yml
+++ b/src/examples/workflow_collector.yml
@@ -24,6 +24,8 @@ usage:
     build-test-and-deploy:
       jobs:
         - sumologic/workflow-collector
+            custom-data: >
+              {"foo": "bar", "$SOME_KEY_VAR": "$SOME_VALUE_VAR"}
         - build
         - test:
             requires:

--- a/src/jobs/workflow-collector.yml
+++ b/src/jobs/workflow-collector.yml
@@ -159,7 +159,7 @@ steps:
 
         # Append any custom data to the workflow data
         ESCAPED_JSON=$(echo '<< parameters.custom-data >>' | sed -E 's/([^\]|^)"/\1\\"/g')
-        CUSTOM_DATA=$(eval "echo $ESCAPED_JSON")`
+        CUSTOM_DATA=$(eval "echo $ESCAPED_JSON")
         if [[ ! -z '<< parameters.custom-data >>' ]] && echo "$CUSTOM_DATA" | jq -e;
         then
             echo "Appending custom data to the workflow data"

--- a/src/jobs/workflow-collector.yml
+++ b/src/jobs/workflow-collector.yml
@@ -13,6 +13,10 @@ parameters:
       type: env_var_name
       default: "CIRCLE_TOKEN"
       description: "Enter your CircleCI Personal Access Token for interacting with the API. You may generate one here: https://circleci.com/account/api"
+  custom-data:
+      type: string
+      default: ""
+      description: "A valid JSON object to append to the workflow data."
 executor: default
 steps:
   - jq/install
@@ -152,6 +156,18 @@ steps:
         # Send end-of-workflow data to Sumologic
         ########################################
         WF_SL_PAYLOAD=$(curl -s "https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID?circle-token=$<< parameters.circle-token >>" | jq '.')
+
+        # Append any custom data to the workflow data
+        ESCAPED_JSON=$(echo '<< parameters.custom-data >>' | sed -E 's/([^\]|^)"/\1\\"/g')
+        CUSTOM_DATA=$(eval "echo $ESCAPED_JSON")`
+        if [[ ! -z '<< parameters.custom-data >>' ]] && echo "$CUSTOM_DATA" | jq -e;
+        then
+            echo "Appending custom data to the workflow data"
+            WF_SL_PAYLOAD=$(echo $WF_SL_PAYLOAD | jq -c ". +  {\"custom_data\": $CUSTOM_DATA}")
+        else
+            echo "No valid custom data found to append to the workflow data"
+        fi
+
         echo "SENDING FINAL WORKFLOW DATA"
         echo $WF_SL_PAYLOAD
         echo $WF_SL_PAYLOAD > /tmp/sumologic-logs/workflow-collector.json


### PR DESCRIPTION
Users can now attach custom data in the form of JSON to the end of workflow payload using the custom-data parameter.

### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

Users can now attach custom data in the form of JSON to the end of workflow payload using the custom-data parameter.

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

Added a string parameter to the orb. If the custom-data parameter contains valid JSON, then it will be attached to the end of workflow data with key "custom-data". Environment variables specified in the string parameter will be interpolated.

Resolves #26 
