### PR TITLE
[semver:minor] docs: update display links

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ workflows:
       # key in CircleCI via SSH Permissions, with github.com as Hostname)
       - orb-tools/trigger-integration-workflow:
           name: trigger-integration-dev
-          ssh-fingerprints: 97:c9:c2:9e:1b:04:ee:ee:99:4d:6b:f7:ce:e0:00:78
+          ssh-fingerprints: bd:e7:6a:3c:67:9c:74:6a:c8:bd:16:de:8d:45:17:e4
           requires:
             - orb-tools/publish-dev
           filters:
@@ -84,7 +84,7 @@ workflows:
       - orb-tools/trigger-integration-workflow:
           name: trigger-integration-master
           cleanup-tags: true
-          ssh-fingerprints: 97:c9:c2:9e:1b:04:ee:ee:99:4d:6b:f7:ce:e0:00:78
+          ssh-fingerprints: bd:e7:6a:3c:67:9c:74:6a:c8:bd:16:de:8d:45:17:e4
           tag: master
           requires:
             - orb-tools/publish-dev
@@ -117,7 +117,7 @@ workflows:
       - orb-tools/dev-promote-prod:
           name: dev-promote-patch
           orb-name: circleci/sumologic
-          ssh-fingerprints: 97:c9:c2:9e:1b:04:ee:ee:99:4d:6b:f7:ce:e0:00:78
+          ssh-fingerprints: bd:e7:6a:3c:67:9c:74:6a:c8:bd:16:de:8d:45:17:e4
           cleanup-tags: true
           requires: *prod-deploy_requires
           filters:
@@ -130,7 +130,7 @@ workflows:
           name: dev-promote-minor
           release: minor
           orb-name: circleci/sumologic
-          ssh-fingerprints: 97:c9:c2:9e:1b:04:ee:ee:99:4d:6b:f7:ce:e0:00:78
+          ssh-fingerprints: bd:e7:6a:3c:67:9c:74:6a:c8:bd:16:de:8d:45:17:e4
           cleanup-tags: true
           requires: *prod-deploy_requires
           filters:
@@ -143,7 +143,7 @@ workflows:
           name: dev-promote-major
           release: major
           orb-name: circleci/sumologic
-          ssh-fingerprints: 97:c9:c2:9e:1b:04:ee:ee:99:4d:6b:f7:ce:e0:00:78
+          ssh-fingerprints: bd:e7:6a:3c:67:9c:74:6a:c8:bd:16:de:8d:45:17:e4
           cleanup-tags: true
           requires: *prod-deploy_requires
           filters:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -1,9 +1,8 @@
 version: 2.1
-
-description: >
-  "Report CircleCI job analytics to your SumoLogic dashboard.
-  Website: sumologic.com
-  Repo: https://github.com/CircleCI-Public/sumologic-orb"
-
 orbs:
-  jq: circleci/jq@1.9.0
+  jq: circleci/jq@2.2
+description: >
+  Report CircleCI job analytics to your SumoLogic dashboard.
+display:
+  home_url: "https://www.sumologic.com/"
+  source_url: "https://github.com/CircleCI-Public/sumologic-orb"


### PR DESCRIPTION
Minor change because last deploy failed due to SSH key permissioned. Resolved that issue and implemented this fix to the orb description links to get the deployment out.